### PR TITLE
feature/154397747/pagination

### DIFF
--- a/Server/controllers/favorites.js
+++ b/Server/controllers/favorites.js
@@ -1,4 +1,5 @@
 import { Recipe, Favorite, User } from '../models';
+import { paginationData } from '../shared/helper';
 
 const favorites = {
 
@@ -87,7 +88,7 @@ const favorites = {
           } else if (fave.userId === request.decoded.id) {
             fave.destroy()
               .then(() => {
-                response.status(204).json({
+                response.status(200).json({
                   status: 'Successful',
                   message: 'Recipe has been removed from your Favorites',
                 });
@@ -119,7 +120,7 @@ const favorites = {
       faves.map(data =>
         recipeIds.push(data.dataValues.recipeId));
 
-      Recipe.findAll({
+      Recipe.findAndCountAll({
         where: {
           id: recipeIds,
         },
@@ -128,9 +129,11 @@ const favorites = {
           model: User,
           attributes: ['firstName', 'surname'],
         }],
+        limit: request.query.limit,
+        offset: request.query.offset,
       })
-        .then((faveRecipes) => {
-          if (faveRecipes.length === 0) {
+        .then(({ rows, count }) => {
+          if (count === 0) {
             response.status(200).json({
               status: 'Successful',
               message: 'You Currently Have No Favorite Recipes',
@@ -139,7 +142,12 @@ const favorites = {
           } else {
             response.status(200).json({
               status: 'Successful',
-              favorites: faveRecipes,
+              favorites: rows,
+              pagination: paginationData(
+                count,
+                request.query.limit,
+                request.query.offset,
+              )
             });
           }
         });

--- a/Server/controllers/ratings.js
+++ b/Server/controllers/ratings.js
@@ -43,7 +43,7 @@ const ratings = {
                   }));
               } else if (votes.vote === 1) {
                 votes.destroy()
-                  .then(() => response.status(204).json({
+                  .then(() => response.status(200).json({
                     status: 'Successful',
                     message: 'Your Vote was Deleted',
                   }));
@@ -106,7 +106,7 @@ const ratings = {
                   }));
               } else if (votes.vote === 0) {
                 votes.destroy()
-                  .then(() => response.status(204).json({
+                  .then(() => response.status(200).json({
                     status: 'Successful',
                     message: 'Your Vote was Deleted',
                   }));

--- a/Server/controllers/users.js
+++ b/Server/controllers/users.js
@@ -94,7 +94,7 @@ const users = {
             status: 'Unsuccessful',
             message: 'User not found',
           });
-        }) // if unsuccessful
+        })
         .catch(error => response.status(500).send(error));
     } else {
       return response.status(406).json({

--- a/Server/index.js
+++ b/Server/index.js
@@ -39,6 +39,7 @@ app.use('/', publicPath);
 app.use('/api/v1/users', users);
 app.use('/api/v1/user', users);
 app.use('/api/v1/recipes', recipes);
+app.use('/api/v1/recipe', recipes);
 app.use('/api/v1/favorites', recipes);
 
 

--- a/Server/routes/recipes.js
+++ b/Server/routes/recipes.js
@@ -20,6 +20,16 @@ router.get(
 );
 
 router.get(
+  '/search/:search',
+  recipe.search
+);
+
+router.get(
+  '/categories/:type',
+  recipe.getCategory
+);
+
+router.get(
   '/:recipeId',
   recipe.getDetails
 );

--- a/Server/shared/helper.js
+++ b/Server/shared/helper.js
@@ -2,7 +2,7 @@ import jwt from 'jsonwebtoken';
 import { Recipe } from '../models';
 
 export const paginationData = (count, limit, offset) => ({
-  pageSize: limit,
+  pageSize: parseInt(limit, 10),
   totalCount: count,
   page: Math.ceil(offset / limit) + 1,
   pageCount: Math.ceil(count / limit),

--- a/Server/shared/validations.js
+++ b/Server/shared/validations.js
@@ -1,18 +1,18 @@
 const userRules = {
-  firstName: 'required|between:2,35',
-  surname: 'required|between:2,50',
+  firstName: 'required|alpha|between:2,35',
+  surname: 'required|alpha|between:2,50',
   email: 'required|email',
-  password: ['required|confirmed|min:6', 'regex:/\s/'],
+  password: 'required|confirmed|min:6|alpha_num',
   password_confirmation: 'required',
 };
 
 const recipeRules = {
-  name: 'required|between:2,90',
-  description: 'between:2,140',
-  prepTime: 'required|min:5',
+  name: 'required|alpha|between:2,90',
+  description: 'alpha|between:2,140',
+  prepTime: 'required|alpha_num|min:5',
   type: 'required',
-  ingredients: 'required|min:5',
-  instructions: 'required|min:10',
+  ingredients: 'required|alpha_dash|min:5',
+  instructions: 'required|alpha_dash|min:10',
 };
 
 const reviewRules = {
@@ -21,17 +21,17 @@ const reviewRules = {
 };
 
 const updateRecipeRules = {
-  name: 'between:2,90',
-  description: 'between:3,140',
-  prepTime: 'between:2,90',
+  name: 'alpha|between:2,90',
+  description: 'alpha|between:3,140',
+  prepTime: 'alpha_num|between:2,90',
   type: 'between:4,90',
-  ingredients: 'between:5,1200',
-  instructions: 'between:10,1200',
+  ingredients: 'alpha_dash|between:5,1200',
+  instructions: 'alpha_dash|between:10,1200',
 };
 
 const updateUserRules = {
-  firstName: 'between:2,35',
-  surname: 'required|between:2,50',
+  firstName: 'alpha|between:2,35',
+  surname: 'alpha|between:2,50',
   email: 'email',
   password: ['confirmed|min:6', 'regex:/\s/']
 };

--- a/client/Index.jsx
+++ b/client/Index.jsx
@@ -11,7 +11,7 @@ import { setCurrentUser } from './actions/signupActions';
 import './assets/style.scss';
 import './assets/init';
 
-const store = createStore(
+export const store = createStore(
   rootReducer,
   compose(
     applyMiddleware(thunk),

--- a/client/actions/favoriteActions.js
+++ b/client/actions/favoriteActions.js
@@ -7,7 +7,7 @@ import { FAVORITE_RECIPE, GET_FAVORITE_RECIPE, DELETE_FAVORITE } from './types';
  * @returns {object} any
  */
 export function favoriteRecipe(recipeId) {
-  return dispatch => axios.post(`/api/v1/recipes/${recipeId}/favorite`)
+  return dispatch => axios.post(`/api/v1/recipe/${recipeId}/favorite`)
     .then((response) => {
       dispatch({
         type: FAVORITE_RECIPE,
@@ -18,11 +18,13 @@ export function favoriteRecipe(recipeId) {
 }
 
 /**
- *  @export {function}
+ * @param {any} limit
+ * @param {any} offset
+ * @export {function}
  * @returns {object} any
  */
-export function getFavoriteRecipes() {
-  return dispatch => axios.get('/api/v1/user/favorites')
+export function getFavoriteRecipes(limit, offset) {
+  return dispatch => axios.get(`/api/v1/user/favorites?limit=${limit}&offset=${offset}`)
     .then((response) => {
       dispatch({
         type: GET_FAVORITE_RECIPE,

--- a/client/actions/ratingActions.js
+++ b/client/actions/ratingActions.js
@@ -9,7 +9,7 @@ import {
  * @returns {object} any
  */
 export function upvoteRecipe(recipeId) {
-  return dispatch => axios.post(`/api/v1/recipes/${recipeId}/upvote`)
+  return dispatch => axios.post(`/api/v1/recipe/${recipeId}/upvote`)
     .then((response) => {
       dispatch({
         type: UPVOTE_RECIPE,
@@ -24,7 +24,7 @@ export function upvoteRecipe(recipeId) {
  * @returns {object} any
  */
 export function downvoteRecipe(recipeId) {
-  return dispatch => axios.post(`/api/v1/recipes/${recipeId}/downvote`)
+  return dispatch => axios.post(`/api/v1/recipe/${recipeId}/downvote`)
     .then((response) => {
       dispatch({
         type: DOWNVOTE_RECIPE,
@@ -39,7 +39,7 @@ export function downvoteRecipe(recipeId) {
  * @returns {object} any
  */
 export function getUpvotes(recipeId) {
-  return dispatch => axios.get(`/api/v1/recipes/${recipeId}/upvotes`)
+  return dispatch => axios.get(`/api/v1/recipe/${recipeId}/upvotes`)
     .then((response) => {
       dispatch({
         type: GET_UPVOTES,
@@ -54,7 +54,7 @@ export function getUpvotes(recipeId) {
  * @returns {object} any
  */
 export function getDownvotes(recipeId) {
-  return dispatch => axios.get(`/api/v1/recipes/${recipeId}/downvotes`)
+  return dispatch => axios.get(`/api/v1/recipe/${recipeId}/downvotes`)
     .then((response) => {
       dispatch({
         type: GET_DOWNVOTES,

--- a/client/actions/recipeActions.js
+++ b/client/actions/recipeActions.js
@@ -11,6 +11,7 @@ import {
   GET_RECIPE,
   GET_RECIPES_CATEGORY,
   SEARCH_RECIPE,
+  GET_PAGED_RECIPES,
   MOST_UPVOTED_RECIPES
 } from './types';
 
@@ -82,11 +83,29 @@ export function getAllRecipes() {
 }
 
 /**
+ * @param {any} limit
+ * @param {any} offset
  * @export {function}
  * @returns {object} any
  */
-export function getUserRecipes() {
-  return dispatch => axios.get('/api/v1/user/recipes')
+export function getPaginatedRecipes(limit, offset) {
+  return dispatch => axios.get(`/api/v1/recipes/?limit=${limit}&offset=${offset}`)
+    .then((response) => {
+      dispatch({
+        type: GET_PAGED_RECIPES,
+        payload: response.data,
+      });
+    });
+}
+
+/**
+ * @param {any} limit
+ * @param {any} offset
+ * @export {function}
+ * @returns {object} any
+ */
+export function getUserRecipes(limit, offset) {
+  return dispatch => axios.get(`/api/v1/user/recipes?limit=${limit}&offset=${offset}`)
     .then((response) => {
       dispatch({
         type: GET_USER_RECIPES,
@@ -144,10 +163,12 @@ export function deleteRecipe(recipeId) {
 /**
  * @export {function}
  * @param {any} type
+ * @param {any} limit
+ * @param {any} offset
  * @returns {object} any
  */
-export function getRecipeCategory(type) {
-  return dispatch => axios.get(`/api/v1/recipes/?type=${type}`)
+export function getRecipeCategory(type, limit, offset) {
+  return dispatch => axios.get(`/api/v1/recipes/categories/${type}?limit=${limit}&offset=${offset}`)
     .then((response) => {
       dispatch({
         type: GET_RECIPES_CATEGORY,
@@ -159,10 +180,12 @@ export function getRecipeCategory(type) {
 /**
  * @export {function}
  * @param {any} word
+ * @param {any} limit
+ * @param {any} offset
  * @returns {object} any
  */
-export function searchRecipe(word) {
-  return dispatch => axios.get(`/api/v1/recipes/?search=${word}`)
+export function searchRecipe(word, limit, offset) {
+  return dispatch => axios.get(`/api/v1/recipes/search/${word}?limit=${limit}&offset=${offset}`)
     .then((response) => {
       dispatch({
         type: SEARCH_RECIPE,

--- a/client/actions/reviewActions.js
+++ b/client/actions/reviewActions.js
@@ -8,7 +8,7 @@ import { REVIEW_RECIPE, GET_REVIEWS, DELETE_REVIEW } from './types';
  * @returns {object} any
  */
 export function reviewRecipe(recipeId, review) {
-  return dispatch => axios.post(`/api/v1/recipes/${recipeId}/review`, review)
+  return dispatch => axios.post(`/api/v1/recipe/${recipeId}/review`, review)
     .then((response) => {
       dispatch({
         type: REVIEW_RECIPE,
@@ -21,10 +21,12 @@ export function reviewRecipe(recipeId, review) {
 /**
  * @export {function}
  * @param {any} recipeId
+ * @param {any} limit
+ * @param {any} offset
  * @returns {object} any
  */
-export function getReviews(recipeId) {
-  return dispatch => axios.get(`/api/v1/recipes/${recipeId}/reviews`)
+export function getReviews(recipeId, limit, offset) {
+  return dispatch => axios.get(`/api/v1/recipe/${recipeId}/reviews?limit=${limit}&offset=${offset}`)
     .then((response) => {
       dispatch({
         type: GET_REVIEWS,
@@ -39,7 +41,7 @@ export function getReviews(recipeId) {
  * @returns {object} any
  */
 export function deleteReview(reviewId) {
-  return dispatch => axios.delete(`/api/v1/recipes/${reviewId}/review`)
+  return dispatch => axios.delete(`/api/v1/recipe/${reviewId}/review`)
     .then((response) => {
       Materialize.toast(`<span> ${response.data.message}</span>`, 2000);
 

--- a/client/actions/types.js
+++ b/client/actions/types.js
@@ -22,3 +22,4 @@ export const UPDATE_USER = 'UPDATE_USER';
 export const GET_USER = 'GET_USER';
 export const SEARCH_RECIPE = 'SEARCH_RECIPE';
 export const MOST_UPVOTED_RECIPES = 'MOST_UPVOTED_RECIPES';
+export const GET_PAGED_RECIPES = 'GET_PAGED_RECIPES';

--- a/client/assets/style.scss
+++ b/client/assets/style.scss
@@ -198,9 +198,14 @@ main {
     height: 180px;
   }
   .home-text-style {
+    margin-right: 3px !important;
     font-size: 14px;
     color: rgb(184, 84, 2) !important;
   }
+}
+
+.pagination li.active {
+  background-color: #FFB63D !important;
 }
 
 #r-cmt {
@@ -229,7 +234,11 @@ main {
 }
 
 .caps {
-  text-transform: capitalize;
+  text-transform: capitalize !important;
+}
+
+a {
+  text-decoration: none;
 }
 
 .caps2 {
@@ -252,7 +261,7 @@ main {
 
 .icon-button {
   border: 0;
-  background-color:  rgba(0, 0, 0, 0.0);
+  background-color:  rgba(0, 0, 0, 0.0) !important;
 }
 
 .card-buttons {
@@ -406,6 +415,10 @@ main {
   margin-left: 2em;
 }
 
+.text-space {
+  padding-left: 6px;
+}
+
 .error-text-field {
   font-size: 13px;
 }
@@ -425,6 +438,10 @@ main {
   padding-top: 1em;
 }
 
+.two-top {
+  margin-top: 2em;
+}
+
 .two-down {
   padding-bottom: 2em;
 }
@@ -432,6 +449,9 @@ main {
 .title-details {
   margin-top: 0 !important;
   text-transform: capitalize !important;
+  .user {
+    padding-left: 10px;
+  }
 }
 
 .slide-pad{

--- a/client/components/App.jsx
+++ b/client/components/App.jsx
@@ -1,5 +1,6 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
+
 import Homepage from './homepage/Homepage';
 import SignupPage from './signup/Signuppage';
 import NavigationBar from './navBar/NavigationBar';
@@ -8,7 +9,8 @@ import AddRecipePage from './addRecipe/AddRecipePage';
 import UpdateRecipePage from './updateRecipe/UpdateRecipePage';
 import RecipeDetails from './recipe/RecipeDetails';
 import Profile from './user/Profile';
-import AllRecipes from './allRecipes/AllRecipes'
+import AllRecipes from './allRecipes/AllRecipes';
+import confirmAuth from './confirmAuth';
 import '../assets/init';
 
 /**
@@ -24,10 +26,10 @@ const App = () => (
       <Switch>
         <Route path="/" exact component={Homepage} />
         <Route path="/signup" component={SignupPage} />
-        <Route path="/addRecipe" component={AddRecipePage} />
-        <Route path="/user" component={Profile} />
-        <Route path="/updateRecipe/:recipeId" component={UpdateRecipePage} />
-        <Route path="/userRecipe/:recipeId" component={RecipeDetails} />
+        <Route path="/addRecipe" component={confirmAuth(AddRecipePage)} />
+        <Route path="/user" component={confirmAuth(Profile)} />
+        <Route path="/updateRecipe/:recipeId" component={confirmAuth(UpdateRecipePage)} />
+        <Route path="/userRecipe/:recipeId" component={confirmAuth(RecipeDetails)} />
         <Route path="/recipe/:recipeId" component={RecipeDetails} />
         <Route path="/allRecipes" component={AllRecipes} />
       </Switch>

--- a/client/components/common/TextFieldGroup.jsx
+++ b/client/components/common/TextFieldGroup.jsx
@@ -22,7 +22,7 @@ export const TextFieldGroup = ({
 );
 
 export const TextFieldGroup2 = ({
-  value, onChange, id, type, name, label, error
+  value, onChange, id, name, label, error
 }) => (
   <div className="input-field">
     <label htmlFor={id}>{label}</label>
@@ -30,7 +30,7 @@ export const TextFieldGroup2 = ({
       value={value}
       onChange={onChange}
       id={id}
-      type={type}
+      type="text"
       className="materialize-textarea"
       name={name}
     />
@@ -51,7 +51,7 @@ export const TextFieldGroup3 = ({
       value={value}
       onChange={onChange}
       id={id}
-      type={type}
+      type="text"
       className="validate"
       name={name}
     />
@@ -110,7 +110,6 @@ TextFieldGroup2.propTypes = {
   id: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
   label: PropTypes.string.isRequired,
-  type: PropTypes.string.isRequired,
   error: PropTypes.arrayOf(PropTypes.any),
 };
 

--- a/client/components/confirmAuth.jsx
+++ b/client/components/confirmAuth.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { Redirect } from 'react-router-dom';
+
+import setAuthorizationToken from '../utils/setAuthorizationToken';
+import { store } from '../Index';
+import { setCurrentUser } from '../actions/signinActions';
+import decodeToken from '../utils/decodeToken';
+
+const confirmAuth = (Component) => {
+  if (!store.getState().auth.isAuthenticated) {
+    return () => <Redirect to="/" />;
+  }
+  if (!decodeToken()) {
+    localStorage.removeItem('jwtToken');
+    localStorage.removeItem('user');
+    setAuthorizationToken(false);
+    store.dispatch(setCurrentUser(undefined, undefined));
+    return () => <Redirect to="/" />;
+  }
+  return props => <Component {...props} />;
+};
+
+export default confirmAuth;

--- a/client/components/homepage/Homepage.jsx
+++ b/client/components/homepage/Homepage.jsx
@@ -78,10 +78,10 @@ class Homepage extends Component {
               {!this.state.isLoading &&
                 <ul className="categories flex-container-homepage">
                   {
-                    upvoted.map((recipe, index) => (
+                    upvoted.map(recipe => (
                       <UpvotedContent
                         recipe={recipe}
-                        key={index}
+                        key={recipe.recipeId}
                       />))
                   }
                 </ul>
@@ -106,10 +106,10 @@ class Homepage extends Component {
               {!this.state.isLoading &&
                 <ul className="categories flex-container-homepage">
                   {
-                    allRecipes.slice(0, 5).map((recipe, index) => (
+                    allRecipes.slice(0, 5).map(recipe => (
                       <AllContent
                         recipe={recipe}
-                        key={index}
+                        key={recipe.id}
                       />))
                   }
                 </ul>
@@ -125,8 +125,12 @@ class Homepage extends Component {
 Homepage.propTypes = {
   getAllRecipes: PropTypes.func.isRequired,
   getMostUpvotedRecipe: PropTypes.func.isRequired,
-  recipes: PropTypes.arrayOf(PropTypes.any).isRequired,
+  recipes: PropTypes.arrayOf(PropTypes.any),
   upvotedRecipes: PropTypes.arrayOf(PropTypes.any).isRequired
+};
+
+Homepage.defaultProps = {
+  recipes: []
 };
 
 const mapStateToProps = state => ({

--- a/client/components/recipe/Details.jsx
+++ b/client/components/recipe/Details.jsx
@@ -19,7 +19,8 @@ const Details = (props) => {
           text-color
           right
           delete-text
-          text-style"
+          text-style
+          white"
           onClick={props.clickEvent}
         >Delete this recipe
         </button>
@@ -42,14 +43,14 @@ const Details = (props) => {
         }
         {(props.ingredients.length > 0) &&
         <div>
-          <div id="time" className="col s4 ">
+          <div id="time" className="col l4 m4 s12 ">
             <p className="recipe"> Prep Time: {props.recipe.prepTime} </p>
           </div>
-          <div id="Ing" className="col s4 r-ingredients">
+          <div id="Ing" className="col l4 m4 s12 r-ingredients">
             <p className="recipe"> Ingredients: </p>
             {props.ingredients}
           </div>
-          <div id="Ins" className="col s4">
+          <div id="Ins" className="col l4 m4 s12">
             <p className="recipe"> Instructions: </p>
             <p id="instruct" className="no-top"> {props.recipe.instructions} </p>
           </div>
@@ -71,13 +72,14 @@ Details.propTypes = {
   clickEvent: PropTypes.func.isRequired,
   recipe: PropTypes.objectOf(PropTypes.any),
   ingredients: PropTypes.arrayOf(PropTypes.any),
-  id: PropTypes.number.isRequired,
+  id: PropTypes.number,
   isLoading: PropTypes.bool.isRequired
 };
 
 Details.defaultProps = {
   recipe: {},
-  ingredients: []
+  ingredients: [],
+  id: 0
 };
 
 export default Details;

--- a/client/components/recipe/Recipe.jsx
+++ b/client/components/recipe/Recipe.jsx
@@ -51,7 +51,7 @@ const Recipe = props => (
         <div className="col s12 ">
           {props.creator &&
             <p className="title-details top-style"> Posted by
-              <a className="text-color title-details caps" href="user-recipe.html">
+              <a className="text-color user" href="user-recipe.html">
                 {props.creator.firstName}
               </a>
             </p>

--- a/client/components/recipe/ReviewForm.jsx
+++ b/client/components/recipe/ReviewForm.jsx
@@ -42,9 +42,10 @@ class ReviewForm extends Component {
   onSubmit(event) {
     event.preventDefault();
 
-    this.props.reviewRecipe(this.props.recipe.id, this.state)
+    const { recipe, limit, offset } = this.props;
+    this.props.reviewRecipe(recipe.id, this.state)
       .then(() => {
-        this.props.getReviews(this.props.recipe.id);
+        this.props.getReviews(recipe.id, limit, offset);
         this.setState({
           title: '',
           comment: '',
@@ -65,7 +66,7 @@ class ReviewForm extends Component {
         <div className="col s12 reviews-style">
           <p className="text2" > Add a comment to review this recipe </p>
           <div className="row no-top">
-            <form onSubmit={this.onSubmit} className="col s6" ref="reviewForm"> <br />
+            <form onSubmit={this.onSubmit} className="col l5 m10 s12" ref="reviewForm"> <br />
               <div >
                 <div className="input-field text3">
                   <input
@@ -100,7 +101,9 @@ class ReviewForm extends Component {
 ReviewForm.propTypes = {
   reviewRecipe: PropTypes.func.isRequired,
   getReviews: PropTypes.func.isRequired,
-  recipe: PropTypes.objectOf(PropTypes.any).isRequired
+  recipe: PropTypes.objectOf(PropTypes.any).isRequired,
+  limit: PropTypes.number.isRequired,
+  offset: PropTypes.number.isRequired
 };
 
 

--- a/client/components/recipe/Reviews.jsx
+++ b/client/components/recipe/Reviews.jsx
@@ -11,11 +11,10 @@ import PreLoader from '../common/PreLoader';
  */
 class Reviews extends Component {
   /**
-   * @param {any} event
    * @memberof Home
    * @return {void}
    */
-  reviewClickEvent = (event) => {
+  reviewClickEvent = () => {
     this.props.deleteReview(this.props.review.id);
   }
 

--- a/client/components/user/Favorites.jsx
+++ b/client/components/user/Favorites.jsx
@@ -34,7 +34,7 @@ class Favorites extends Component {
             className="caps text-color"
           >
             {favorite.name}
-            <span className="black-text" >
+            <span className="black-text text-space">
               posted by {favorite.User.firstName} {favorite.User.surname}
             </span>
           </Link>

--- a/client/components/user/Information.jsx
+++ b/client/components/user/Information.jsx
@@ -12,7 +12,7 @@ const Information = props => (
           className="materialboxed responsive-img circle img-style"
           width="200px"
           src={props.profile.image ||
-            this.state.image ||
+            props.image ||
             '/images/profilepic.png'}
         />
         {props.isPicLoading &&
@@ -36,7 +36,7 @@ const Information = props => (
             <span> Upload Photo
               <i className="material-icons left">photo</i>
             </span>
-            <input type="file" onChange={this.uploadImage} />
+            <input type="file" onChange={props.uploadImage} />
           </div>
         </div>
       </div>
@@ -46,7 +46,9 @@ const Information = props => (
 
 Information.propTypes = {
   profile: PropTypes.objectOf(PropTypes.any),
-  isPicLoading: PropTypes.bool.isRequired
+  isPicLoading: PropTypes.bool.isRequired,
+  image: PropTypes.string.isRequired,
+  uploadImage: PropTypes.func.isRequired
 };
 
 Information.defaultProps = {

--- a/client/reducers/favoriteRecuder.js
+++ b/client/reducers/favoriteRecuder.js
@@ -2,7 +2,7 @@ import {
   FAVORITE_RECIPE, GET_FAVORITE_RECIPE, DELETE_FAVORITE
 } from '../actions/types';
 
-const initialState = { message: '', favorites: [] };
+const initialState = { message: '', favorites: [], pagination: {} };
 
 export default (state = initialState, action = {}) => {
   switch (action.type) {
@@ -16,7 +16,8 @@ export default (state = initialState, action = {}) => {
       return {
         ...state,
         favorites: action.payload.favorites,
-        message: action.payload.message,
+        pagination: action.payload.pagination,
+        message: action.payload.message
       };
     case DELETE_FAVORITE:
       return {

--- a/client/reducers/ratingsReducer.js
+++ b/client/reducers/ratingsReducer.js
@@ -1,6 +1,11 @@
-import { UPVOTE_RECIPE, DOWNVOTE_RECIPE, GET_UPVOTES, GET_DOWNVOTES } from '../actions/types';
+import {
+  UPVOTE_RECIPE,
+  DOWNVOTE_RECIPE,
+  GET_UPVOTES,
+  GET_DOWNVOTES
+} from '../actions/types';
 
-const initialState = { upvotes: [], downvotes: [] };
+const initialState = { upvotes: {}, downvotes: {} };
 
 export default (state = initialState, action = {}) => {
   switch (action.type) {

--- a/client/reducers/recipeReducer.js
+++ b/client/reducers/recipeReducer.js
@@ -5,6 +5,7 @@ import {
   DELETE_RECIPE,
   UPDATE_RECIPE,
   GET_RECIPE,
+  GET_PAGED_RECIPES,
   GET_RECIPES_CATEGORY,
   MOST_UPVOTED_RECIPES,
   SEARCH_RECIPE
@@ -15,6 +16,7 @@ const initialState = {
   upvotedRecipes: [],
   currentRecipe: {},
   message: '',
+  pagination: {}
 };
 
 export default (state = initialState, action = {}) => {
@@ -28,6 +30,7 @@ export default (state = initialState, action = {}) => {
       return {
         ...state,
         recipes: action.payload.recipes,
+        pagination: action.payload.pagination,
         message: action.payload.message,
       };
     case GET_ALL_RECIPES:
@@ -36,11 +39,18 @@ export default (state = initialState, action = {}) => {
         recipes: action.payload.recipes,
         message: action.payload.message
       };
+    case GET_PAGED_RECIPES:
+      return {
+        ...state,
+        recipes: action.payload.recipes,
+        pagination: action.payload.pagination
+      };
     case GET_RECIPES_CATEGORY:
       return {
         ...state,
         recipes: action.payload.recipes,
-        message: action.payload.message,
+        pagination: action.payload.pagination,
+        message: action.payload.message
       };
     case MOST_UPVOTED_RECIPES:
       return {
@@ -52,6 +62,7 @@ export default (state = initialState, action = {}) => {
       return {
         ...state,
         recipes: action.payload.recipes,
+        pagination: action.payload.pagination,
         message: action.payload.message
       };
     case GET_RECIPE:

--- a/client/reducers/reviewReducer.js
+++ b/client/reducers/reviewReducer.js
@@ -1,6 +1,6 @@
 import { REVIEW_RECIPE, GET_REVIEWS, DELETE_REVIEW } from '../actions/types';
 
-const initialState = { reviews: [], message: '' };
+const initialState = { reviews: [], message: '', pagination: {} };
 
 export default (state = initialState, action = {}) => {
   switch (action.type) {
@@ -13,6 +13,7 @@ export default (state = initialState, action = {}) => {
       return {
         ...state,
         reviews: action.payload.reviews,
+        pagination: action.payload.pagination,
         message: action.payload.message,
       };
     case DELETE_REVIEW:

--- a/client/utils/decodeToken.js
+++ b/client/utils/decodeToken.js
@@ -1,0 +1,17 @@
+import jwt from 'jsonwebtoken';
+
+const decodeToken = () => {
+  const userToken = localStorage.getItem('jwToken');
+  if (userToken) {
+    return jwt.verify(userToken, process.env.SECRET_KEY, ((error) => {
+      if (!error) {
+        return true;
+      }
+      localStorage.removeItem('jwToken');
+      return false;
+    }));
+  }
+  return false;
+};
+
+export default decodeToken;

--- a/package-lock.json
+++ b/package-lock.json
@@ -3174,6 +3174,14 @@
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-4.0.0.tgz",
       "integrity": "sha1-hk7xN5rO1Vzm+V3r7NzhefegzR0="
     },
+    "dotenv-webpack": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/dotenv-webpack/-/dotenv-webpack-1.5.4.tgz",
+      "integrity": "sha1-nJLkbkEqHPvGAhftM9adK7/dv58=",
+      "requires": {
+        "dotenv": "4.0.0"
+      }
+    },
     "dottie": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/dottie/-/dottie-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "cross-env": "^5.1.1",
     "css-loader": "^0.28.7",
     "dotenv": "^4.0.0",
+    "dotenv-webpack": "^1.5.4",
     "es-feature-tests": "^0.3.0",
     "eslint": "^4.15.0",
     "eslint-config-airbnb": "^16.1.0",

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const webpack = require('webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
+const Dotenv = require('dotenv-webpack');
 
 const HtmlWebpackPluginConfig = new HtmlWebpackPlugin({
   template: './client/index.html',
@@ -31,6 +32,10 @@ module.exports = {
     new webpack.NoEmitOnErrorsPlugin(),
     new webpack.optimize.OccurrenceOrderPlugin(),
     new webpack.HotModuleReplacementPlugin(),
+    new Dotenv({
+      path: './.env', // Path to .env file
+      systemvars: true // load all system variables as well (useful for CI purposes)
+    }),
     HtmlWebpackPluginConfig
   ],
   module: {

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -28,7 +28,8 @@ module.exports = {
   plugins: [
     new ExtractTextPlugin('./style.css'),
     new webpack.DefinePlugin({
-      'process.env.NODE_ENV': JSON.stringify('production')
+      'process.env.NODE_ENV': JSON.stringify('production'),
+      'process.env.SECRET_KEY': JSON.stringify(process.env.SECRET_KEY)
     }),
     new UglifyJsPlugin({
       uglifyOptions: {


### PR DESCRIPTION
#### Description of Task to be completed?
 * write the front-end functions for paginating Recipes, Reviews and Favorites
 * added to the existing html and css code for Recipes and Reviews catalog
 * improved and wrote new API functions on the back-end implementation to support pagination
* improved app's responsiveness

#### How should this be manually tested?
Have the app working by:
 * run the command `npm run start:dev` on the command line to start the server
 * once app is running, navigate to the app using `localhost:8000`
 * scroll down to view `All Recipes` on the homepage 
 * click the link, pagination is available immediately at the bottom of the page
 * click on a recipe name to view a recipe, scroll down to reviews or click on `Reviews` to scroll 
    automatically
 * if there are reviews, click on `Older posts` to view pagination
 * sign up / sign in, click on username name on the navbar to access a link to your profile
 * navigate `Recipes` or `Favorites` tab to view pagination for those pages


 #### Any background context you want to provide?
 Nil

 #### What are the relevant pivotal tracker stories?
154397747

 #### Screenshots (if appropriate)
  